### PR TITLE
Feature: Configuration Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,18 @@ authorName: AUTHOR
 description: DESCRIPTION
 ---
 ```
+
+## Configuration
+
+You can add your data to a `yaml` file and use it to provide metadata to your page.
+
+```yaml
+pageTitle: TITLE
+authorName: AUTHOR
+description: DESCRIPTION
+version: VERSION
+author:
+  name: AUTHOR
+  email: EMAIL
+github: GITHUB
+```

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -24,6 +24,8 @@ var rootCmd = &cobra.Command{
 		if output == "" {
 			output = fileNameWithoutExtension + ".html"
 		}
+		projectConfigFileName := cmd.Flag("config-file").Value.String()
+		utils.LoadConfig(projectConfigFileName)
 		convertedFileData, err := convert(inputFileName, output)
 		if err != nil {
 			log.Fatal(err)
@@ -83,8 +85,8 @@ func convert(inputFileName string, output string) (string, error) {
 	if err != nil {
 		panic(err)
 	}
-	for _, v := range utils.Metadata {
-		templateHtml = strings.Replace(string(templateHtml), "$"+v, metadataValues[v], -1)
+	for k, v := range metadataValues {
+		templateHtml = strings.Replace(string(templateHtml), "$"+k, v, -1)
 	}
 	templateHtml = strings.Replace(string(templateHtml), "$data", htmlFormatOfFile, 1)
 	return string(templateHtml), nil
@@ -94,5 +96,6 @@ func Execute() {
 	rootCmd.Flags().StringP("file", "f", "", "The file to convert")
 	rootCmd.MarkFlagRequired("file")
 	rootCmd.Flags().StringP("output", "o", "", "The output file")
+	rootCmd.Flags().StringP("config-file", "c", "", "Project Configuration file")
 	rootCmd.Execute()
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module md2htm
 
 go 1.21.6
 
-require github.com/spf13/cobra v1.8.0
+require (
+	github.com/spf13/cobra v1.8.0
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,5 +6,7 @@ github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Use a `yaml` file with specified format in the README.md to provide default metadata for your static HTML sites