### PR TITLE
fix: rm escape for inline code tags

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,7 @@
   <meta name="author" content="Akkaraju Satvik &lt;satvik.akkaraju@gmail.com&gt;">
   <meta name="description" content="Markdown to HTML converter">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
-  <title>Home | md2htm</title>
+  <title>Page Title | md2htm</title>
 	<style>
 		* {
 			font-family: sans-serif;
@@ -91,7 +91,7 @@ md2htm -f &lt;input.md&gt; -t &lt;template-file&gt;</code></pre>
 
 <h2> Output</h2>
 
-<p>The output will be saved in the &amp;amp;lt;code&amp;amp;gt;outputDir&amp;amp;lt;/code&amp;amp;gt; specified in the configuration file. If no output directory is specified, the output will be saved in the &amp;lt;code&amp;gt;dist&amp;lt;/code&amp;gt; directory and the file name will be the same as the input file with the &lt;code&gt;.html&lt;/code&gt; extension unless the <code>--output-file</code> flag is used to specify a custom output file.</p>
+<p>The output will be saved in the <code>outputDir</code> specified in the configuration file. If no output directory is specified, the output will be saved in the <code>dist</code> directory and the file name will be the same as the input file with the <code>.html</code> extension unless the <code>--output-file</code> flag is used to specify a custom output file.</p>
 
 <pre><code class="language-bash">md2htm -f &lt;input.md&gt; --output-file &lt;output-file&gt;
 # or

--- a/lib/tags.go
+++ b/lib/tags.go
@@ -37,9 +37,11 @@ func HandleLists(fileLines *[]string, i int, k string) int {
 func HandleInlineCode(lineContent string) string {
 	tickCount := strings.Count(lineContent, "`")
 	for i := 0; i < tickCount/2; i++ {
-		lineContent = html.EscapeString(lineContent)
 		lineContent = strings.Replace(lineContent, "`", "<code>", 1)
 		lineContent = strings.Replace(lineContent, "`", "</code>", 1)
+		inlineCode := lineContent[strings.Index(lineContent, "<code>")+6 : strings.Index(lineContent, "</code>")]
+		inlineCode = html.EscapeString(inlineCode)
+		lineContent = strings.Replace(lineContent, lineContent[strings.Index(lineContent, "<code>"):strings.Index(lineContent, "</code>")+7], "<code>"+inlineCode+"</code>", 1)
 		lineContent = strings.Replace(lineContent, "<code></code>", "``", -1)
 		lineContent = strings.Replace(lineContent, "</code><code>", "``", -1)
 	}


### PR DESCRIPTION
escape only the content of the inline codes